### PR TITLE
Add configuration for building wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,69 @@
+name: Build for macos, manylinux and windows. Publish to pypi if a release.
+on: [pull_request, push]
+
+env:
+
+  CIBW_BUILD_VERBOSITY: 3
+  CIBW_BUILD: 'cp37-* cp38-* cp39-* cp310-*'
+  CIBW_SKIP: '*-manylinux_i686 *-musllinux_* *-win32'
+  CIBW_BEFORE_BUILD: pip install cython
+  CIBW_TEST_REQUIRES: pytest numpy scipy
+  CIBW_TEST_COMMAND: pytest -s -v {project}/tests
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: |
+          pip install cython
+          python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,24 @@
+name: Run tests
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+
+    steps:
+        - uses: actions/checkout@v1
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.python-version }}
+
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            python -m pip install tox tox-gh-actions cython
+
+        - name: Test with tox
+          run: tox

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ src/libvoro++.a
 *.o
 *.so
 *.pyc
+.eggs
 tess/_voro.cpp
 examples/walls/torus
 examples/walls/tetrahedron
@@ -37,3 +38,4 @@ __pycache__
 /docs/.build
 /docs/.templates
 /docs/.static
+.tox/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.rst
 include LICENSE
 recursive-include src *.cc *.hh
-include tess/_voro.pyx
+include tess/_voro.pyx tess/_voro.cpp

--- a/tests/test_tess.py
+++ b/tests/test_tess.py
@@ -1,4 +1,4 @@
-from . import Container
+from tess import Container
 from unittest import TestCase
 
 from math import sqrt
@@ -8,6 +8,39 @@ try:
     import scipy
 except ImportError:
     scipy = None
+
+
+def test_cell_methods():
+    """Simple checks for the Cell method bindings
+    """
+    cell_positions = [[1., 1., 1.], [2., 2., 2.]]
+    cell_radii = [0.2, 0.1]
+
+    cells = Container(
+        cell_positions, radii=cell_radii, limits=(3,3,3), periodic=False
+    )
+
+    for i, cell in enumerate(cells):
+
+        assert cell.id == i
+        assert np.allclose(cell.pos, cell_positions[i])
+        assert np.isclose(cell.radius, cell_radii[i])
+        assert cell.volume() > 0.0
+        assert cell.max_radius_squared() > 0.0
+        assert cell.total_edge_distance() > 0.0
+        assert cell.surface_area() > 0.0
+        assert cell.number_of_faces() > 0
+        assert cell.number_of_edges() > 0
+        assert len(cell.centroid()) == 3
+        assert len(cell.vertex_orders()) > 0
+        assert len(cell.vertices()) > 0
+        assert len(cell.face_areas()) > 0
+        assert len(cell.face_freq_table()) > 0
+        assert len(cell.face_vertices()) > 0
+        assert len(cell.face_perimeters()) > 0
+        assert len(cell.normals()) > 0
+        assert len(cell.neighbors()) > 0
+        assert str(cell) == repr(cell) == f"<Cell {i}>"
 
 
 class LatticeTest:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+envlist =
+    py{37,38,39,310}
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+
+[testenv]
+deps =
+    pytest
+extras = tests
+changedir = docs
+commands =
+    pytest --doctest-modules {envsitepackagesdir}/tess
+    pytest {toxinidir}/tests/ {posargs}
+    make doctest
+whitelist_externals =
+    cd
+    make


### PR DESCRIPTION
@wackywendell , I would like to first thank you for this package, which helped me a lot through my studies. In return, I would like to contribute to the building of wheels so that this tool can be easily used in different systems without compilation, which many times could prove tedious.

Summary of changes:

* setuptools transparently fallbacks to using the cpp file when cython is not available, therefore no need for a manual switch.
* Added github workflow for building wheels for linux, mac os and windows using cibuildwheel (py37-310)
* Added github workflow for running the tests.
* Replaced nose with the more recent and maintained pytest.
* Moved the tests in a dedicated tests/ folder so that they work better with pytest.
* Added a tox.ini which standardizes the testing (See https://tox.wiki/en/latest/)
* Added setuptools_scm, which allows extracting python package version via the git metadata (No need for manually changing a version on the setup.py. Making a release and a tag propagates the version to the package via setuptools_scm). 

These changes maintained the current functionality of using cython to compile the pyx file whenever cython is available, otherwise compiling the cpp source, which is bundled with the package. However, imho it would be cleaner and more robust if the project strictly used cython, allowing to add a pyproject.toml config with the cython dependency as a build requirement. Then if needed to be built from source, cython would be required and no intermediate files would need to be used, otherwise one could install the wheels and easily use the package.

To enable the wheel publishing to pypi step, a new release with its respective tag vX.X.X needs to be made.

Closes #9